### PR TITLE
Replace deprecated numeric argument passing with enum passing

### DIFF
--- a/lib/HTTP/Server/Tiny.pm6
+++ b/lib/HTTP/Server/Tiny.pm6
@@ -36,7 +36,7 @@ my class TempFile {
         $.fh.read: $bytes
     }
 
-    method seek(Int:D $offset, Int:D $whence) {
+    method seek(Int:D $offset, SeekType:D $whence) {
         $.fh.seek($offset, $whence);
     }
 
@@ -237,7 +237,7 @@ my class HTTP::Server::Tiny::Handler {
     }
 
     method !run-app() {
-        %!env<p6sgi.input>.seek(0,0); # rewind
+        %!env<p6sgi.input>.seek(0,SeekFromBeginning); # rewind
 
         my ($status, $headers, $body) = sub {
             CATCH {


### PR DESCRIPTION
We should pass `SeekType` argument to `IO::Handle::seek` now.

```
================================================================================
numerical seektype 0 seen at:
  /home/syohei/src/p6/HTTP-Server-Tiny/lib/HTTP/Server/Tiny.pm6, line 39
Please use SeekFromBeginning instead.
--------------------------------------------------------------------------------
Please contact the author to have these occurrences of deprecated code
adapted, so that this message will disappear!
```
