### PR TITLE
IO::Socket::Async#bytes-supply was deprecated

### DIFF
--- a/lib/HTTP/Server/Tiny.pm6
+++ b/lib/HTTP/Server/Tiny.pm6
@@ -477,7 +477,7 @@ method !handler(IO::Socket::Async $conn, Callable $app) {
         }
     }
 
-    my $bs = $conn.bytes-supply;
+    my $bs = $conn.Supply(:bin);
     my $pipelined_buf;
     my $handler = HTTP::Server::Tiny::Handler.new(
         use-keepalive      => $.max-keepalive-reqs != 1,


### PR DESCRIPTION
Use .Supply(:bin) instead of bytes-supply.

```
Method bytes-supply (from IO::Socket::Async) seen at:
  /home/syohei/p6-HTTP-Server-Tiny/lib/HTTP/Server/Tiny.pm6, line 480
Please use Supply(:bin) instead.
```

See https://github.com/rakudo/rakudo/commit/b2e6ca0150b1548a2974f8624e6c59c3ae578a84
