### PR TITLE
Replace deprecated from-json() with JSON::Fast.

### DIFF
--- a/META.info
+++ b/META.info
@@ -13,6 +13,7 @@
   ],
   "description" : "a simple HTTP server for Perl6",
   "test-depends" : [
+    "JSON::Fast",
     "HTTP::Tinyish"
   ],
   "version" : "*",

--- a/t/04-get.t
+++ b/t/04-get.t
@@ -1,6 +1,7 @@
 use v6;
 
 use Test;
+use JSON::Fast;
 use lib 't/lib';
 use Test::TCP;
 use HTTP::Server::Tiny;


### PR DESCRIPTION
According to the documentation it's a drop-in replacement, and either Panda or
dependencies further upstream already use it, so this should add no dependencies
beyond what's already in play.