### PR TITLE
Fix supply test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /src/*.o
 /src/Makefile
 /.panda-work
+.precomp

--- a/t/bin/test-client
+++ b/t/bin/test-client
@@ -1,0 +1,13 @@
+#!/usr/bin/env perl6
+
+use HTTP::Tinyish;
+
+sub MAIN(Int $port) {
+    my $resp = HTTP::Tinyish.new.post("http://127.0.0.1:$port/",
+        headers => { 
+                    'content-type' => 'application/x-www-form-urlencoded'
+        },
+        content => 'foo=bar');
+
+    say $resp<content>;
+}


### PR DESCRIPTION
Hi,
This fixes #33 and #31 

It seems like there is a deadlock on  the socket when using a Supply which doesn't occur when using a plain Channel. The same problem doesn't occur when using the identical server and client code as separate processes.  I've noticed the same problem using NativeCall functions that create a socket to a server in the same process.

I've fixed the symptom of the problem by moving the client part of the Supply test into a separate script and executing it, which works fine and achieves the aim of the test by exercising the Supply response body.

This probably points to a deeper problem within rakudo or moarvm, but this is a viable workaround for the time being.

Thanks.
