### PR TITLE
Remove the build step from the .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ install:
   - rakudobrew build-panda
   - panda --notests installdeps .
 script:
-  - perl6 -MPanda::Builder -e 'Panda::Builder.new.build($*CWD)'
   - PERL6LIB=$PWD/lib prove -e perl6 -r t/
 sudo: false


### PR DESCRIPTION
This isn't needed (there is nothing to build) and was causing a failure.

The tests were passing but the failed build step was causing a problem.