### PR TITLE
Add Control promise for main loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ METHODS
 
 Create new instance.
 
-  * `$server.run(Callable $app)`
+  * `$server.run(Callable $app, Promise :$control-promise)`
 
-Run http server with P6SGI app.
+Run http server with P6SGI app. The named parameter ```control-promise```
+if provided, can be _kept_ to quit the server loop, which may be useful
+if the server is run asynchronously to the main thread of execution in
+an application.
 
 TODO
 ====
@@ -47,6 +50,6 @@ TODO
 COPYRIGHT AND LICENSE
 =====================
 
-Copyright 2015 Tokuhiro Matsuno <tokuhirom@gmail.com>
+Copyright 2015, 2016 Tokuhiro Matsuno <tokuhirom@gmail.com>
 
 This library is free software; you can redistribute it and/or modify it under the Artistic License 2.0.

--- a/lib/HTTP/Server/Tiny.pm6
+++ b/lib/HTTP/Server/Tiny.pm6
@@ -455,7 +455,7 @@ my sub scan-psgi-body($body) {
 }
 
 
-method run(HTTP::Server::Tiny:D: Callable $app) {
+method run(HTTP::Server::Tiny:D: Callable $app, Promise :$control-promise = Promise.new) {
     # moarvm doesn't handle SIGPIPE correctly. Without this,
     # perl6 exit without any message.
     # -- tokuhirom@20151003
@@ -467,6 +467,9 @@ method run(HTTP::Server::Tiny:D: Callable $app) {
     react {
         whenever IO::Socket::Async.listen($.host, $.port) -> $conn {
             self!handler($conn, $app);
+        }
+        whenever $control-promise {
+            done;
         }
     }
 }

--- a/lib/HTTP/Server/Tiny.pm6
+++ b/lib/HTTP/Server/Tiny.pm6
@@ -469,6 +469,7 @@ method run(HTTP::Server::Tiny:D: Callable $app, Promise :$control-promise = Prom
             self!handler($conn, $app);
         }
         whenever $control-promise {
+            debug("Exiting on control promise");
             done;
         }
     }
@@ -566,9 +567,12 @@ HTTP::Server::Tiny is a standalone HTTP/1.1 web server for perl6.
 
 Create new instance.
 
-=item C<$server.run(Callable $app)>
+=item C<$server.run(Callable $app, Promise :$control-promise)>
 
-Run http server with P6SGI app.
+Run http server with P6SGI app C<$app>. 
+
+If the optional named parameter C<control-promise> is provided with a
+C<Promise> then the server loop will be quit when the promise is kept.
 
 =head1 TODO
 
@@ -576,7 +580,7 @@ Run http server with P6SGI app.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2015 Tokuhiro Matsuno <tokuhirom@gmail.com>
+Copyright 2015, 2016 Tokuhiro Matsuno <tokuhirom@gmail.com>
 
 This library is free software; you can redistribute it and/or modify it under the Artistic License 2.0.
 

--- a/t/13-promise.t
+++ b/t/13-promise.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl6
+
+use v6.c;
+
+use Test;
+
+plan 3;
+
+use HTTP::Server::Tiny;
+
+my $control-promise = Promise.in(2);
+
+my $server-promise = start {
+    HTTP::Server::Tiny.new(port => 11273).run(sub ($env) { }, :$control-promise);
+}
+
+my $timeout-promise = Promise.in(15);
+
+await Promise.anyof($server-promise, $timeout-promise);
+
+ok $control-promise, "control-promise is kept";
+ok $server-promise, "server completed on command";
+nok $timeout-promise, "and just to be sure it didn't timeout";
+
+done-testing;
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
Add an optional named ```control-promise``` to .run(), this allows the react to be quit under external control.

When the supplied ```Promise``` is _kept_ the ```react``` loop will be exited with a ```done```.  The default is a Promise that is private to the method and can't be kept.

This is useful when, for example, the server is embedded in a larger application (it also simplifies extended testing of such an application.)