### PR TITLE
Catch the "broken pipe" Exception in the send-content method

### DIFF
--- a/lib/HTTP/Server/Tiny.pm6
+++ b/lib/HTTP/Server/Tiny.pm6
@@ -262,6 +262,13 @@ my class HTTP::Server::Tiny::Handler {
     }
 
     method !send-response($status, $headers, $body) {
+
+        CATCH {
+            when /"broken pipe"/ {
+                debug("client close sending response");
+                return;
+            }
+        }
         debug "sending response $status";
 
         my $resp_string = "$!protocol $status {get_http_status_msg $status}\r\n";


### PR DESCRIPTION
This handles the not entirely unexpected case where the client closes
the socket, for example when they hit escape on a long running response.

Fixes #28