### PR TITLE
Fix test 06-channel.t failure.

### DIFF
--- a/t/06-channel.t
+++ b/t/06-channel.t
@@ -7,7 +7,7 @@ use Test::TCP;
 use HTTP::Server::Tiny;
 use HTTP::Tinyish;
 
-plan 1;
+plan 2;
 
 my $port = 15555;
 
@@ -15,24 +15,31 @@ my $server = HTTP::Server::Tiny.new(host => '127.0.0.1', port => $port);
 
 my $channel = Channel.new;
 
-start {
-    for 1..100 {
-                $channel.send($_.Str.encode('utf-8'));
-    }
-    $channel.close;
-};
-
 Thread.start({
     $server.run(sub ($env) {
         return 200, ['Content-Type' => 'text/plain'], $channel
     });
 }, :app_lifetime);
 
+start {
+    for 1..100 {
+                $channel.send($_.Str.encode('utf-8'));
+    }
+    $channel.close;
+    ok True, "Filled channel";
+}
+
 wait_port($port);
-my $resp = HTTP::Tinyish.new.post("http://127.0.0.1:$port/",
-   headers => { 
+my $resp = HTTP::Tinyish.new.post(
+  "http://127.0.0.1:$port/",
+   headers => {
         'content-type' => 'application/x-www-form-urlencoded'
     },
-    content => 'foo=bar');
-is($resp<content>, "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899100");
+    content => 'foo=bar'
+);
 
+is(
+  $resp<content>,
+  "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899100",
+  "Received channel content as response from post request"
+);

--- a/t/06-channel.t
+++ b/t/06-channel.t
@@ -25,6 +25,7 @@ start {
     for 1..100 {
                 $channel.send($_.Str.encode('utf-8'));
     }
+    sleep 0.1;
     $channel.close;
     ok True, "Filled channel";
 }


### PR DESCRIPTION
Start the server thread before filling the channel appears to fix the channel test from failing.
Added always true test to help diag the completion of filling the channel.

Resolves issue #39 (failing t/06-channel.t) on my Debian vm running Rakudo version 2017.04.3-172-gf2af3db built on MoarVM version 2017.04-56-g8ad18b8