### PR TITLE
Print errors with newline, as P6W spec recommendation

### DIFF
--- a/lib/HTTP/Server/Tiny.pm6
+++ b/lib/HTTP/Server/Tiny.pm6
@@ -17,7 +17,7 @@ my class HandleSupplier {
         my $supplier = Supplier.new;
         my $self = self.bless(supplier => $supplier, handle => $handle);
         my $supply = $supplier.Supply;
-        $supply.tap(-> $v { $self.handle.print($v) });
+        $supply.tap(-> $v { $self.handle.say($v) });
         return $self;
     }
 }

--- a/t/14-error.t
+++ b/t/14-error.t
@@ -20,7 +20,7 @@ Thread.start({
     $server.run(sub ($env) {
         $env<p6w.errors>.emit("foo");
         $env<p6w.errors>.emit("bar");
-        $env<p6w.errors>.emit("baz\nval\n");
+        $env<p6w.errors>.emit("baz\nval");
         return
             200,
             ['Content-Type' => 'application/json'],
@@ -36,4 +36,4 @@ ok $resp<success>;
 is $resp<content>, 'hello';
 
 $io.seek(0);
-is $io.slurp-rest, "foobarbaz\nval\n";
+is $io.slurp-rest, "foo\nbar\nbaz\nval\n";


### PR DESCRIPTION
https://github.com/zostay/P6W#203-the-error-stream

> If written to a typical file handle, it should automatically append a newline to each emitted message.